### PR TITLE
check if cloud event message was already processed

### DIFF
--- a/services/emailer/src/namex_emailer/services/__init__.py
+++ b/services/emailer/src/namex_emailer/services/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from cachetools import TTLCache
 from gcp_queue.pubsub import GcpQueue
 
 queue = GcpQueue()
+ce_cache = TTLCache(maxsize=12000, ttl=1200)


### PR DESCRIPTION
only send email if message id is not in the cache. keep cloud event id in the cache for 20 minutes. limit cache to 12000 entries

*Issue #, if available:*

Looks like the risk of duplicate notifications with push pubsub is unavoidable, e.g. see: https://stackoverflow.com/questions/58440154/how-to-fix-multiple-messages-from-push-subscription-in-gcp-pub-sub

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
